### PR TITLE
Scilpy merge part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,19 @@ before_install:
     - python --version # just to check
     - virtualenv venv
     - source venv/bin/activate
+    - pip install nose coverage coveralls
+    - deactivate
+    - source venv/bin/activate
 
 install:
     - pip install --timeout=60 --no-index --trusted-host $WHEELHOST --find-links $WHEELHOUSE $DEPENDS
-    - pip install $DEPENDS_PIP nose coverage coveralls
-    - python setup.py install
-    - echo 'import sys; print(sys.executable)' > test.py
-    - python test.py
+    - pip install $DEPENDS_PIP
+    - python setup.py build_ext -i
 
 script:
-    - nosetests --verbose --exe --with-coverage --cover-package=nlsam nlsam/tests
+    - mkdir tester
+    - cd tester
+    - nosetests --verbose --exe --with-coverage --cover-package=nlsam ../nlsam/tests/
 
-after_success:
-    - coveralls
+#after_success:
+#    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
     # To test minimum dependencies
     - python: 2.7
       env:
-        - COVERAGE=1
         - DEPENDS="cython==0.21 numpy==1.10.4 scipy==0.12 nibabel==1.3"
         - DEPENDS_PIP="cythongsl==0.2.1 dipy==0.11"
     - python: 2.7
@@ -34,28 +33,18 @@ notifications:
 
 before_install:
     - python --version # just to check
-    - virtualenv $VENV_ARGS venv
+    - virtualenv venv
     - source venv/bin/activate
 
 install:
-    - if [ "${COVERAGE}" == "1" ]; then
-      pip install coverage coveralls;
-      fi
-
     - pip install --timeout=60 --no-index --trusted-host $WHEELHOST --find-links $WHEELHOUSE $DEPENDS
-    - pip install $DEPENDS_PIP nose
+    - pip install $DEPENDS_PIP nose coverage coveralls
     - python setup.py install
+    - echo 'import sys; print(sys.executable)' > test.py
+    - python test.py
 
-# command to run tests, e.g. python setup.py test
 script:
-    # Change into an innocuous directory and find tests from installation
-    - mkdir for_testing
-    - cd for_testing
-    - if [ "${COVERAGE}" == "1" ]; then
-      cp ../.coveragerc .;
-      COVER_ARGS="--with-coverage --cover-package nlsam";
-      fi
-    - nosetests --verbose $COVER_ARGS nlsam
+    - nosetests --verbose --exe --with-coverage --cover-package=nlsam nlsam/tests
 
 after_success:
-    - if [ "${COVERAGE}" == "1" ]; then coveralls; fi
+    - coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # ChangeLog
 
-## [Unreleased]
+## [0.2] - 2016-04-18
+
+- stabilization script is now clipping values to zero (Bai et al. 2014) as used in the paper.
+The previous release was using the Koay et al. 2009 approach, which could produce negative values in really noisy cases.
 
 - More doc to the readme.
 - Added link to the synthetic and in vivo data used in the experiments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # ChangeLog
 
 ## [Unreleased]
-### Added
-- Linux binary nows needs glibc >= 2.13 (Debian wheezy and newer) instead of glibc >= 2.21 (Ubuntu 15.04 and newer)
+
+- More doc to the readme.
+- Added link to the synthetic and in vivo data used in the experiments.
+- Windows binaries are now smaller.
+- Linux binaries now needs glibc >= 2.13 (Debian 7 and newer) instead of glibc >= 2.21 (Ubuntu 15.04 and newer).
+- Removed the source archive and wheel files, as one can grab the source archive from github instead.
 
 ## [0.1] - 2016-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# ChangeLog
+
+## [Unreleased]
+### Added
+- Linux binary nows needs glibc >= 2.13 (Debian wheezy and newer) instead of glibc >= 2.21 (Ubuntu 15.04 and newer)
+
+## [0.1] - 2016-03-22
+
+- First release.
+- Windows and Linux binaries available for download.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# ChangeLog
+# Changelog
 
 ## [0.2] - 2016-04-18
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 [paper]: http://scil.dinf.usherbrooke.ca/wp-content/papers/stjean-etal-media16.pdf
 [Anaconda]: https://www.continuum.io/downloads
 [spams-windows]:https://github.com/samuelstjean/spams-python/releases/download/0.1/spams-python-v2.4-svn2013-06-24.win-amd64-py2.7.exe
+[nlsam_data]:https://github.com/samuelstjean/nlsam_data
 
 The reference implementation for the Non Local Spatial and Angular Matching (NLSAM) denoising algorithm for diffusion MRI.
 
 ## How to install
 
 Go grab a [release][] (recommended) or build it from source with the [instructions](#Dependencies).
+You can also download the datasets used in the paper over [here][nlsam_data].
 
 ## Using the NLSAM algorithm
 

--- a/nlsam/smoothing.py
+++ b/nlsam/smoothing.py
@@ -1,19 +1,18 @@
 from __future__ import division
 
 import numpy as np
-from numpy.lib.stride_tricks import as_strided as ast
-# import warnings
 
 from multiprocessing import Pool, cpu_count
 from warnings import warn
 
 from dipy.core.geometry import cart2sphere
-from dipy.reconst.shm import sph_harm_ind_list, real_sph_harm #, lazy_index
+from dipy.reconst.shm import sph_harm_ind_list, real_sph_harm
 from dipy.denoise.noise_estimate import piesno
 
 from scipy.ndimage.filters import convolve, gaussian_filter
 from scipy.ndimage.interpolation import zoom
-# from scipy.special import digamma
+
+from nlsam.utils import sliding_window
 
 
 def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
@@ -44,33 +43,21 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
             please use a lower value".format(similarity_threshold))
 
     m, n = sph_harm_ind_list(sh_order)
-    # where_b0s = lazy_index(gtab.b0s_mask)
     where_b0s = gtab.b0s_mask
-    # where_dwi = lazy_index(~gtab.b0s_mask)
     pred_sig = np.zeros_like(data)
 
     # Round similar bvals together for identifying similar shells
-    bvals = gtab.bvals  #[where_dwi]
+    bvals = gtab.bvals
     rounded_bvals = np.zeros_like(bvals)
 
     for unique_bval in np.unique(bvals):
         idx = np.abs(unique_bval - bvals) < similarity_threshold
         rounded_bvals[idx] = unique_bval
 
-    # print(rounded_bvals, rounded_bvals.shape)
-    # print(np.unique(bvals))
-    # 1/0
-
-
     # process each b-value separately
     for unique_bval in np.unique(rounded_bvals):
         idx = rounded_bvals == unique_bval
-        # print(idx.shape)
-        # # print(unique_bval)
-        # print(np.all(idx == where_b0s))
-        # print(idx, idx.shape)
-        # print(where_b0s, where_b0s.shape)
-        # 1/0
+
         # Just give back the signal for the b0s since we can't really do anything about it
         if np.all(idx == where_b0s):
             if np.sum(gtab.b0s_mask) > 1:
@@ -81,7 +68,8 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
 
         # If it's not a b0, check if enough data for requested sh order
         if np.sum(idx) < (sh_order + 1) * (sh_order + 2) / 2:
-            warn("bval {} has not enough values for sh order {}.\nPutting back the original values.".format(unique_bval, sh_order))
+            warn("bval {} has not enough values for sh order {}." \
+                 "\nPutting back the original values.".format(unique_bval, sh_order))
             pred_sig[..., idx] = data[..., idx]
             continue
 
@@ -243,94 +231,3 @@ def local_piesno(data, N, size=5, return_mask=True):
         return interpolated, m_out
 
     return interpolated
-
-
-# Stolen from http://www.johnvinyard.com/blog/?p=268
-def sliding_window(a, ws, ss=None, flatten=True):
-    '''
-    Return a sliding window over a in any number of dimensions
-
-    Parameters:
-        a  - an n-dimensional numpy array
-        ws - an int (a is 1D) or tuple (a is 2D or greater) representing the size
-             of each dimension of the window
-        ss - an int (a is 1D) or tuple (a is 2D or greater) representing the
-             amount to slide the window in each dimension. If not specified, it
-             defaults to ws.
-        flatten - if True, all slices are flattened, otherwise, there is an
-                  extra dimension for each dimension of the input.
-
-    Returns
-        an array containing each n-dimensional window from a
-    '''
-
-    if None is ss:
-        # ss was not provided. the windows will not overlap in any direction.
-        ss = ws
-    ws = norm_shape(ws)
-    ss = norm_shape(ss)
-
-    # convert ws, ss, and a.shape to numpy arrays so that we can do math in every
-    # dimension at once.
-    ws = np.array(ws)
-    ss = np.array(ss)
-    shape = np.array(a.shape)
-
-    # ensure that ws, ss, and a.shape all have the same number of dimensions
-    ls = [len(shape), len(ws), len(ss)]
-    if 1 != len(set(ls)):
-        raise ValueError('a.shape, ws and ss must all have the same length. They were %s' % str(ls))
-
-    # ensure that ws is smaller than a in every dimension
-    if np.any(ws > shape):
-        raise ValueError('ws cannot be larger than a in any dimension.\
- a.shape was %s and ws was %s' % (str(a.shape), str(ws)))
-
-    # how many slices will there be in each dimension?
-    newshape = norm_shape(((shape - ws) // ss) + 1)
-    # the shape of the strided array will be the number of slices in each dimension
-    # plus the shape of the window (tuple addition)
-    newshape += norm_shape(ws)
-    # the strides tuple will be the array's strides multiplied by step size, plus
-    # the array's strides (tuple addition)
-    newstrides = norm_shape(np.array(a.strides) * ss) + a.strides
-    strided = ast(a, shape=newshape, strides=newstrides)
-    if not flatten:
-        return strided
-
-    # Collapse strided so that it has one more dimension than the window.  I.e.,
-    # the new array is a flat list of slices.
-    meat = len(ws) if ws.shape else 0
-    firstdim = (np.product(newshape[:-meat]),) if ws.shape else ()
-    dim = firstdim + (newshape[-meat:])
-    # remove any dimensions with size 1
-    dim = filter(lambda i: i != 1, dim)
-    return strided.reshape(dim)
-
-
-def norm_shape(shape):
-    '''
-    Normalize numpy array shapes so they're always expressed as a tuple,
-    even for one-dimensional shapes.
-
-    Parameters
-        shape - an int, or a tuple of ints
-
-    Returns
-        a shape tuple
-    '''
-    try:
-        i = int(shape)
-        return (i,)
-    except TypeError:
-        # shape was not a number
-        pass
-
-    try:
-        t = tuple(shape)
-        return t
-    except TypeError:
-        # shape was not iterable
-        pass
-
-    raise TypeError('shape must be an int, or a tuple of ints')

--- a/nlsam/tests/test_stabilizer.py
+++ b/nlsam/tests/test_stabilizer.py
@@ -3,14 +3,18 @@
 from __future__ import division, print_function
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal
 
 from scipy.special import factorialk
 from scipy.stats import norm
 
-from nlsam.stabilizer import (_test_marcumq_cython, _test_beta,
-    _test_fixed_point_k, _test_xi, fixed_point_finder, chi_to_gauss,
-    _test_inv_cdf_gauss, _test_multifactorial)
+from nlsam.stabilizer import (_test_marcumq_cython,
+                              _test_beta,
+                              _test_xi,
+                              fixed_point_finder,
+                              chi_to_gauss,
+                              _test_inv_cdf_gauss,
+                              _test_multifactorial)
 
 # hispeed is the closed source java reference implementation,
 # from which most values are taken from.
@@ -39,8 +43,11 @@ def test_xi():
 
 def test_fixed_point_finder():
     # Values taken from hispeed.SignalFixedPointFinder.fixedPointFinder
-    assert_almost_equal(fixed_point_finder(50, 30, 12), -192.78288201533618)
-    assert_almost_equal(fixed_point_finder(650, 45, 1), 648.4366584016703)
+    assert_almost_equal(fixed_point_finder(50, 30, 12), 0)
+    assert_almost_equal(fixed_point_finder(650, 400, 1), 452.287728081486)
+    assert_almost_equal(fixed_point_finder(650, 40, 12), 620.9909935398028)
+    assert_almost_equal(fixed_point_finder(65, 40, 12), 0)
+    assert_almost_equal(fixed_point_finder(15, 4, 4), 10.420401964259176)
 
 
 def test_chi_to_gauss():

--- a/nlsam/tests/test_stabilizer.py
+++ b/nlsam/tests/test_stabilizer.py
@@ -5,7 +5,11 @@ from __future__ import division, print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from scipy.special import factorialk
+try:
+    from scipy.special import factorialk
+except ImportError:
+    from scipy.misc import factorialk
+
 from scipy.stats import norm
 
 from nlsam.stabilizer import (_test_marcumq_cython,


### PR DESCRIPTION
'Bugfix' for the stabilizer script. The scilpy version was using the Bai et al. 2014 approach (no negative values in m_hat) while the one I put here was using the Koay et al. 2009 approach (allow negative m_hat to have symmetry near zero). 

This PR fixes this to reflect the approach used in the paper and also adds a small changelog. 