### PR TITLE
cleanup for 0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## [0.2] - 2016-04-18
+## [0.2] - 2016-04-19
 
 - stabilization script is now clipping values to zero (Bai et al. 2014) as used in the paper.
 The previous release was using the Koay et al. 2009 approach, which could produce negative values in really noisy cases.
 
 - More doc to the readme.
 - Added link to the synthetic and in vivo data used in the experiments.
-- Windows binaries are now smaller.
 - Linux binaries now needs glibc >= 2.13 (Debian 7 and newer) instead of glibc >= 2.21 (Ubuntu 15.04 and newer).
 - Removed the source archive and wheel files, as one can grab the source archive from github instead.
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python
 
+modlist = ['nlsam.utils',
+           'nlsam.stabilizer']
+
+params = {}
+params['name'] = 'nlsam'
+params['version'] = '0.2'
+params['requires'] = ['cythongsl>=0.2.1',
+                      'numpy>=1.10.4',
+                      'cython>=0.21']
+params['deps'] = ['scipy>=0.12',
+                  'nibabel>=1.3',
+                  'spams>=2.4']
+params['links'] = ['https://github.com/samuelstjean/spams-python/archive/master.zip#egg=spams-2.5']
+
+###############################################
+# Build stuff is below this line
+###############################################
+
 import os
 from os.path import join, exists, splitext
 
@@ -36,16 +54,6 @@ if not have_cython_gsl:
     raise ImportError('cannot find gsl package (required for hyp1f1), \
         try pip install cythongsl and sudo apt-get install libgsl0-dev libgsl0ldbl')
 
-params = {}
-params['name'] = 'nlsam'
-params['version'] = '0.1'
-params['requires'] = ['cythongsl>=0.2.1',
-                      'numpy>=1.10.4',
-                      'cython>=0.21']
-params['deps'] = ['scipy>=0.12',
-                  'nibabel>=1.3',
-                  'spams>=2.4']
-params['links'] = ['https://github.com/samuelstjean/spams-python/archive/master.zip#egg=spams-2.5']
 
 # Check for local version of dipy if it exists, since it would replace a locally built
 # but not installed version.
@@ -60,8 +68,6 @@ if LooseVersion(dipy.__version__) <= '0.11':
     raise ValueError('Local dipy version is {}, but you need at least 0.11!'.format(dipy.__version__))
 
 ext_modules = []
-modlist = ['nlsam.utils',
-           'nlsam.stabilizer']
 
 for pyxfile in modlist:
 


### PR DESCRIPTION
Smaller binaries will have to come at a later point sadly, but in the meantime people can enjoy the stabilization script as published/available through scilpy.