### PR TITLE
Fix overflow sh dtype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ install:
     - python setup.py build_ext -i
     - python setup.py install
 
+before_script:
+    - mkdir $HOME/.python-eggs
+    - chmod og-w $HOME/.python-eggs
+
 script:
     - mkdir tester
     - cd tester

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- sh_smooth now uses order 8 by default and a regularized pseudo-inverse for the fit.
+The data is also internally converted to float32 to prevent overflowing on uint dtypes. Thanks to Felix Morency for reporting.
 - Updated nibabel min version to 2.0, as older version do not have the cache unload function. Thanks to Rutger Fick for reporting.
 - Scripts are now more memory friendly with nibabel uncaching.
 - The example was moved to a subfolder with an available test dataset.

--- a/nlsam/smoothing.py
+++ b/nlsam/smoothing.py
@@ -28,7 +28,7 @@ def sh_smooth(data, gtab, sh_order=8, similarity_threshold=50, regul=0.006):
         Order of the spherical harmonics to fit.
 
     similarity_threshold : int, default 50
-        All bvalues such that |b_1 - b_2| < similarity_threshold
+        All b-values such that |b_1 - b_2| < similarity_threshold
         will be considered as identical for smoothing purpose.
         Must be lower than 200.
 
@@ -71,11 +71,11 @@ def sh_smooth(data, gtab, sh_order=8, similarity_threshold=50, regul=0.006):
             continue
 
         # If it's not a b0, check if enough data for requested sh order
-        if np.sum(idx) < (sh_order + 1) * (sh_order + 2) / 2:
-            warn("bval {} has not enough values for sh order {}."
-                 "\nPutting back the original values.".format(unique_bval, sh_order))
-            pred_sig[..., idx] = data[..., idx]
-            continue
+        # if np.sum(idx) < (sh_order + 1) * (sh_order + 2) / 2:
+        #     warn("bval {} has not enough values for sh order {}."
+        #          "\nPutting back the original values.".format(unique_bval, sh_order))
+        #     pred_sig[..., idx] = data[..., idx]
+        #     continue
 
         x, y, z = gtab.gradients[idx].T
         r, theta, phi = cart2sphere(x, y, z)

--- a/nlsam/smoothing.py
+++ b/nlsam/smoothing.py
@@ -6,7 +6,7 @@ from multiprocessing import Pool, cpu_count
 from warnings import warn
 
 from dipy.core.geometry import cart2sphere
-from dipy.reconst.shm import sph_harm_ind_list, real_sph_harm
+from dipy.reconst.shm import sph_harm_ind_list, real_sph_harm, smooth_pinv
 from dipy.denoise.noise_estimate import piesno
 
 from scipy.ndimage.filters import convolve, gaussian_filter
@@ -15,7 +15,7 @@ from scipy.ndimage.interpolation import zoom
 from nlsam.utils import sliding_window
 
 
-def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
+def sh_smooth(data, gtab, sh_order=8, similarity_threshold=50, regul=0.006):
     """Smooth the raw diffusion signal with spherical harmonics.
 
     data : ndarray
@@ -24,13 +24,16 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
     gtab : gradient table object
         Corresponding gradients table object to data.
 
-    sh_order : int, default 4
+    sh_order : int, default 8
         Order of the spherical harmonics to fit.
 
     similarity_threshold : int, default 50
         All bvalues such that |b_1 - b_2| < similarity_threshold
         will be considered as identical for smoothing purpose.
         Must be lower than 200.
+
+    regul : float, default 0.006
+        Amount of regularization to apply to sh coefficients computation.
 
     Return
     ---------
@@ -39,12 +42,13 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
     """
 
     if similarity_threshold > 200:
-        raise ValueError("similarity_threshold = {}, which is higher than 200, \
-            please use a lower value".format(similarity_threshold))
+        raise ValueError("similarity_threshold = {}, which is higher than 200,"
+            " please use a lower value".format(similarity_threshold))
 
     m, n = sph_harm_ind_list(sh_order)
+    L = -n * (n + 1)
     where_b0s = gtab.b0s_mask
-    pred_sig = np.zeros_like(data)
+    pred_sig = np.zeros_like(data, dtype=np.float32)
 
     # Round similar bvals together for identifying similar shells
     bvals = gtab.bvals
@@ -68,7 +72,7 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
 
         # If it's not a b0, check if enough data for requested sh order
         if np.sum(idx) < (sh_order + 1) * (sh_order + 2) / 2:
-            warn("bval {} has not enough values for sh order {}." \
+            warn("bval {} has not enough values for sh order {}."
                  "\nPutting back the original values.".format(unique_bval, sh_order))
             pred_sig[..., idx] = data[..., idx]
             continue
@@ -78,10 +82,11 @@ def sh_smooth(data, gtab, sh_order=4, similarity_threshold=50):
 
         # Find the sh coefficients to smooth the signal
         B_dwi = real_sph_harm(m, n, theta[:, None], phi[:, None])
-        sh_coeff = np.linalg.lstsq(B_dwi, data[..., idx].reshape(np.prod(data.shape[:-1]), -1).T)[0]
+        invB = smooth_pinv(B_dwi, np.sqrt(regul) * L)
+        sh_coeff = np.dot(data[..., idx], invB.T)
 
         # Find the smoothed signal from the sh fit for the given gtab
-        pred_sig[..., idx] = np.dot(B_dwi, sh_coeff).T.reshape(data.shape[:-1] + (-1,))
+        pred_sig[..., idx] = np.dot(sh_coeff, B_dwi.T)
 
     return pred_sig
 

--- a/nlsam/tests/test_scripts.sh
+++ b/nlsam/tests/test_scripts.sh
@@ -25,10 +25,10 @@ check_return_code $?
 
 # Test on niftis
 gunzip dwi.nii.gz mask.nii.gz
-stabilizer dwi.nii dwi_stab_localstd.nii 1 sigma_localstd.nii -m mask.nii --bvals bvals --bvecs bvecs --noise_est local_std --smooth no_smoothing
+stabilizer dwi.nii dwi_stab_localstd.nii 1 sigma_localstd.nii -m mask.nii --bvals bvals --bvecs bvecs --noise_est local_std --smooth no_smoothing --sh_order 6
 check_return_code $?
 
-stabilizer dwi.nii dwi_stab_piesno.nii 1 sigma_piesno.nii -m mask.nii --bvals bvals --bvecs bvecs
+stabilizer dwi.nii dwi_stab_piesno.nii 1 sigma_piesno.nii -m mask.nii --bvals bvals --bvecs bvecs --sh_order 6
 check_return_code $?
 
 nlsam dwi_stab_localstd.nii dwi_nlsam_localstd.nii 5 bvals bvecs sigma_localstd.nii -m mask.nii

--- a/scripts/stabilizer
+++ b/scripts/stabilizer
@@ -96,6 +96,10 @@ def buildArgsParser():
                    'Also requires the bvals/bvecs to be given.\n' +
                    'no_smoothing : Just use the data as-is for initialisation.')
 
+    p.add_argument('--sh_order', action='store', dest='sh_order',
+                   metavar='int', default=8, type=int,
+                   help='SH order used for sh_smooth. (Default: 8)')
+
     p.add_argument('--bvals', action='store', dest='bvals',
                    metavar='bvals', type=str, default='',
                    help='Path of the bvals file, in FSL format. \n' +
@@ -165,6 +169,7 @@ def main():
 
     noise_method = args.noise_method
     smooth_method = args.smooth_method
+    sh_order = args.sh_order
 
     if noise_method == 'noise_map':
         if args.noise_maps is None:
@@ -178,9 +183,19 @@ def main():
         m_hat = np.array(data, copy=True, dtype=np.float32)
 
     elif smooth_method == 'sh_smooth':
+
+        # Raise warning for sh order if there is not enough DWIs
+        if data.shape[-1] < (sh_order + 1) * (sh_order + 2) / 2:
+            print("We recommend having at least " +
+                  str((sh_order + 1) * (sh_order + 2) / 2) +
+                  " unique DWIs volumes, but you currently have " +
+                  str(data.shape[-1]) + " volumes. Try lowering the " +
+                  "parameter --sh_order in case of non convergence.")
+
         bvals, bvecs = read_bvals_bvecs(args.bvals, args.bvecs)
         gtab = gradient_table(bvals, bvecs)
-        m_hat = sh_smooth(data, gtab, sh_order=4)
+        m_hat = sh_smooth(data, gtab, sh_order=sh_order)
+        m_hat[m_hat < 0] = 0
 
     print("Estimating noise with method " + noise_method)
 


### PR DESCRIPTION
sh_smooth now uses order 8 by default and a regularized pseudo-inverse for the fit. A command line switch --sh_order was added to change this behavior (default was order 4 before, but about 99% of voxels are unchanged by this new initialisation)

The data is also internally converted to float32 to prevent overflowing on uint dtypes.