### PR TITLE
Save original header in final nifti file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1] - 2016-07-11
+
+- The original header is now saved back as-is to prevent potential conflicts
+with other processing tools. Thanks to Derek Pisner for reporting.
+
 ## [0.3] - 2016-05-13
 
 - sh_smooth now uses order 8 by default and a regularized pseudo-inverse for the fit.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include requirements.txt
 include LICENSE
 include README.md
 include CHANGELOG.md

--- a/nlsam/tests/test_scripts.sh
+++ b/nlsam/tests/test_scripts.sh
@@ -10,6 +10,10 @@ function check_return_code()
         exit 1
     fi
 }
+
+# Crop example dataset
+python -c 'import nibabel as nib; import numpy as np; d = nib.load("dwi.nii.gz").get_data(); nib.save(nib.Nifti1Image(d[70:80],np.eye(4)), "dwi.nii.gz")'
+
 # Test on example dataset
 stabilizer dwi.nii.gz dwi_stab_localstd.nii.gz 1 sigma_localstd.nii.gz -m mask.nii.gz --bvals bvals --bvecs bvecs --noise_est local_std --smooth no_smoothing
 check_return_code $?

--- a/nlsam/tests/test_scripts.sh
+++ b/nlsam/tests/test_scripts.sh
@@ -13,6 +13,7 @@ function check_return_code()
 
 # Crop example dataset
 python -c 'import nibabel as nib; import numpy as np; d = nib.load("dwi.nii.gz").get_data(); nib.save(nib.Nifti1Image(d[70:80],np.eye(4)), "dwi.nii.gz")'
+python -c 'import nibabel as nib; import numpy as np; d = nib.load("mask.nii.gz").get_data(); nib.save(nib.Nifti1Image(d[70:80],np.eye(4)), "mask.nii.gz")'
 
 # Test on example dataset
 stabilizer dwi.nii.gz dwi_stab_localstd.nii.gz 1 sigma_localstd.nii.gz -m mask.nii.gz --bvals bvals --bvecs bvecs --noise_est local_std --smooth no_smoothing

--- a/scripts/nlsam
+++ b/scripts/nlsam
@@ -89,6 +89,8 @@ def main():
     vol = nib.load(args.input)
     data = np.asarray(vol.get_data(caching='unchanged'))  # To force ndarray instead of memmaps
     affine = vol.get_affine()
+    header = vol.get_header()
+    header.set_data_dtype(np.float32)
 
     sigma = nib.load(args.sigma).get_data()**2
 
@@ -227,7 +229,7 @@ def main():
 
         data_denoised = data_denoised_insert
 
-    nib.save(nib.Nifti1Image(data_denoised.astype(original_dtype), affine), args.output)
+    nib.save(nib.Nifti1Image(data_denoised.astype(np.float32), affine, header), args.output)
 
 
 if __name__ == "__main__":

--- a/scripts/stabilizer
+++ b/scripts/stabilizer
@@ -80,13 +80,13 @@ def buildArgsParser():
     p.add_argument('--noise_map', action='store', dest='noise_maps',
                    metavar='string', required=False, default=None, type=str,
                    help='Path of the noise map(s) volume for local piesno.\n'
-                   'Either supply a 3D noise map or a stack of 3D maps as a 4D volume.\n'+
+                   'Either supply a 3D noise map or a stack of 3D maps as a 4D volume.\n' +
                    'Required for --noise_est noise_map')
 
     p.add_argument('--noise_mask', action='store', dest='save_piesno_mask',
                    metavar='string', required=False, default=None, type=str,
-                   help='If supplied, output filename for saving the mask of noisy voxels '
-                   + 'found by PIESNO.')
+                   help='If supplied, output filename for saving the mask of noisy voxels ' +
+                   'found by PIESNO.')
 
     p.add_argument('--smooth', action='store', dest='smooth_method',
                    metavar='string', required=False, default='sh_smooth', type=str,
@@ -148,6 +148,8 @@ def main():
     vol = nib.load(args.input)
     data = np.asarray(vol.get_data(caching='unchanged'))  # To force ndarray instead of memmaps
     affine = vol.get_affine()
+    header = vol.get_header()
+    header.set_data_dtype(np.float32)
 
     if args.mask is None:
         mask = np.ones(data.shape[:-1], dtype=np.bool)
@@ -251,7 +253,7 @@ def main():
     for idx in range(len(data_out)):
         data_stabilized[..., idx, :] = data_out[idx]
 
-    nib.save(nib.Nifti1Image(data_stabilized, affine), args.output)
+    nib.save(nib.Nifti1Image(data_stabilized, affine, header), args.output)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ params['name'] = 'nlsam'
 params['author'] = 'Samuel St-Jean'
 params['author_email'] = 'samuel@isi.uu.nl'
 params['url'] = 'https://github.com/samuelstjean/nlsam'
-params['version'] = '0.3'
+params['version'] = '0.3.1'
 params['requires'] = ['cythongsl>=0.2.1',
                       'numpy>=1.10.4',
                       'cython>=0.21']


### PR DESCRIPTION
To prevent problems with other software, the exact input header is saved back with a modified dtype.